### PR TITLE
Adding configuration of adguard port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@ ARG TARGETARCH
 
 WORKDIR /tmp/adguard_exporter
 
-RUN echo "${TARGETOS}-${TARGETARCH}" && apk --no-cache add git alpine-sdk upx
+RUN apk --no-cache add git alpine-sdk
 COPY . .
 RUN GO111MODULE=on go mod vendor
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags '-s -w' -o adguard_exporter ./
-RUN upx -f --brute adguard_exporter
 
 FROM scratch
 LABEL name="adguard-exporter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM --platform=$BUILDPLATFORM golang:1.15-alpine3.12 AS build
+FROM golang:1.15-alpine3.12 as build
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /tmp/adguard_exporter
 
-RUN apk --no-cache add git alpine-sdk upx
+RUN echo "${TARGETOS}-${TARGETARCH}" && apk --no-cache add git alpine-sdk upx
 COPY . .
 RUN GO111MODULE=on go mod vendor
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags '-s -w' -o adguard_exporter ./
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags '-s -w' -o adguard_exporter ./
 RUN upx -f --brute adguard_exporter
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ docker run \
 -e 'adguard_hostname=192.168.10.252' \
 -e 'adguard_username=admin' \
 -e 'adguard_password=mypassword' \
+-e 'adguard_port=' \ #optional if adguard is not using port 80 (http)/443 (https)
 -e 'interval=10s' \
 -e 'log_limit=10000' \
 -e 'server_port=9617' \
@@ -120,7 +121,8 @@ services:
       - adguard_protocol=http
       - adguard_hostname=192.168.10.252
       - adguard_username=admin
-      - adguard_password=/run/secrets/my-adguard-pass 
+      - adguard_password=/run/secrets/my-adguard-pass
+      - adguard_port= #optional
       - interval=10s
       - log_limit=10000
 ```
@@ -150,7 +152,8 @@ services:
       - adguard_protocol=http
       - adguard_hostname=192.168.10.252
       - adguard_username=admin
-      - adguard_password=/run/secrets/my-adguard-pass 
+      - adguard_password=/run/secrets/my-adguard-pass
+      - adguard_port= #optional
       - interval=10s
       - log_limit=10000
 ```
@@ -219,6 +222,9 @@ scrape_configs:
 # Password defined on the Adguard interface
 -adguard_password string (optional)
 
+# Port to use to communicate with Adguard API
+-adguard_port string (optional)
+
 # Limit for the return log data
 -log_limit string (optional) (default "1000")
 
@@ -256,7 +262,7 @@ After=syslog.target network-online.target
 Requires=AdGuardHome.Service
 
 [Service]
-ExecStart=/opt/adguard_exporter/adguard_exporter-linux-arm -adguard_protocol http -adguard_hostname <hostname> -adguard_username <username> -adguard_password <password> -log_limit 5000
+ExecStart=/opt/adguard_exporter/adguard_exporter-linux-arm -adguard_protocol http -adguard_hostname <hostname> -adguard_username <username> -adguard_password <password> -adguard_port <port> -log_limit 5000
 Restart=on-failure
 RestartSec=10s
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ After=syslog.target network-online.target
 Requires=AdGuardHome.Service
 
 [Service]
-ExecStart=/opt/adguard_exporter/adguard_exporter-linux-arm -adguard_protocol http -adguard_hostname <hostname> -adguard_username <username> -adguard_password <password> -adguard_port <port> -log_limit 5000
+ExecStart=/opt/adguard_exporter/adguard_exporter-linux-arm -adguard_protocol http -adguard_hostname <hostname> -adguard_username <username> -adguard_password <password> -log_limit 5000
 Restart=on-failure
 RestartSec=10s
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
 	"time"
 
@@ -22,7 +23,7 @@ type Config struct {
 	AdguardPort     string        `config:"adguard_port"`
 	ServerPort      string        `config:"server_port"`
 	Interval        time.Duration `config:"interval"`
-    LogLimit        string        `config:"log_limit"`
+	LogLimit        string        `config:"log_limit"`
 }
 
 func getDefaultConfig() *Config {
@@ -31,10 +32,10 @@ func getDefaultConfig() *Config {
 		AdguardHostname: "127.0.0.1",
 		AdguardUsername: "",
 		AdguardPassword: "",
-		AdguardPort:     "",
+		AdguardPort:     "80",
 		ServerPort:      "9617",
 		Interval:        10 * time.Second,
-    LogLimit:        "1000",
+		LogLimit:        "1000",
 	}
 }
 
@@ -50,7 +51,20 @@ func Load() *Config {
 	cfg := getDefaultConfig()
 	err := loader.Load(context.Background(), cfg)
 	if err != nil {
-		panic(err)
+		log.Printf("Could not load the configuration...")
+		os.Exit(1)
+	}
+
+	//Set the adguard port based on the input configuration
+	if cfg.AdguardPort == "" {
+		if cfg.AdguardProtocol == "http" {
+			cfg.AdguardPort = "80"
+		} else if cfg.AdguardProtocol == "https" {
+			cfg.AdguardPort = "443"
+		} else {
+			log.Printf("protocol %s is invalid. Must be http or https.", cfg.AdguardProtocol)
+			os.Exit(1)
+		}
 	}
 
 	cfg.show()

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -19,9 +19,10 @@ type Config struct {
 	AdguardHostname string        `config:"adguard_hostname"`
 	AdguardUsername string        `config:"adguard_username"`
 	AdguardPassword string        `config:"adguard_password"`
+	AdguardPort     string        `config:"adguard_port"`
 	ServerPort      string        `config:"server_port"`
 	Interval        time.Duration `config:"interval"`
-  LogLimit        string        `config:"log_limit"`
+    LogLimit        string        `config:"log_limit"`
 }
 
 func getDefaultConfig() *Config {
@@ -30,6 +31,7 @@ func getDefaultConfig() *Config {
 		AdguardHostname: "127.0.0.1",
 		AdguardUsername: "",
 		AdguardPassword: "",
+		AdguardPort:     "",
 		ServerPort:      "9617",
 		Interval:        10 * time.Second,
     LogLimit:        "1000",

--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -42,13 +42,17 @@ func NewClient(protocol, hostname, username, password, adport string, interval t
 		os.Exit(1)
 	}
 
-	if httpport == "" {
+	if adport == "" {
 		port = 80
 		if protocol == "https" {
 			port = 443
 		}
 	} else {
-		port = uint16(adport)
+		temp, err := strconv.Atoi(adport)
+		if err != nil {
+			log.Fatal(err)
+		}
+		port = uint16(temp)
 	}
 
 	return &Client{

--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -37,23 +36,12 @@ type Client struct {
 
 // NewClient method initializes a new AdGuard  client.
 func NewClient(protocol, hostname, username, password, adport string, interval time.Duration, logLimit string) *Client {
-	if protocol != "http" && protocol != "https" {
-		log.Printf("protocol %s is invalid. Must be http or https.", protocol)
-		os.Exit(1)
+	
+	temp, err := strconv.Atoi(adport)
+	if err != nil {
+		log.Fatal(err)
 	}
-
-	if adport == "" {
-		port = 80
-		if protocol == "https" {
-			port = 443
-		}
-	} else {
-		temp, err := strconv.Atoi(adport)
-		if err != nil {
-			log.Fatal(err)
-		}
-		port = uint16(temp)
-	}
+	port = uint16(temp)
 
 	return &Client{
 		protocol: protocol,

--- a/internal/adguard/client.go
+++ b/internal/adguard/client.go
@@ -36,15 +36,19 @@ type Client struct {
 }
 
 // NewClient method initializes a new AdGuard  client.
-func NewClient(protocol, hostname string, username, password string, interval time.Duration, logLimit string) *Client {
+func NewClient(protocol, hostname, username, password, adport string, interval time.Duration, logLimit string) *Client {
 	if protocol != "http" && protocol != "https" {
 		log.Printf("protocol %s is invalid. Must be http or https.", protocol)
 		os.Exit(1)
 	}
 
-	port = 80
-	if protocol == "https" {
-		port = 443
+	if httpport == "" {
+		port = 80
+		if protocol == "https" {
+			port = 443
+		}
+	} else {
+		port = uint16(adport)
 	}
 
 	return &Client{
@@ -194,7 +198,7 @@ func (c *Client) MakeRequest(url string) []byte {
 		log.Fatal("An error has occurred when creating HTTP statistics request", err)
 	}
 
-	req.Host = "adguard.home-lab.io"
+	req.Host = c.hostname
 	req.Header.Add("User-Agent", "Mozilla/5.0")
 
 	if c.isUsingPassword() {

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ func main() {
 
 	metrics.Init()
 
-	initAdguardClient(conf.AdguardProtocol, conf.AdguardHostname, conf.AdguardUsername, conf.AdguardPassword, conf.Interval, conf.LogLimit)
+	initAdguardClient(conf.AdguardProtocol, conf.AdguardHostname, conf.AdguardUsername, conf.AdguardPassword, conf.AdguardPort, conf.Interval, conf.LogLimit)
 	initHttpServer(conf.ServerPort)
 
 	handleExitSignal()
 }
 
-func initAdguardClient(protocol, hostname string, username, password string, interval time.Duration, logLimit string) {
-	client := adguard.NewClient(protocol, hostname, username, password, interval, logLimit)
+func initAdguardClient(protocol, hostname, username, password, port string, interval time.Duration, logLimit string) {
+	client := adguard.NewClient(protocol, hostname, username, password, port, interval, logLimit)
 	go client.Scrape()
 }
 


### PR DESCRIPTION
For people not running on http or https with default ports 80/443. 
Added a configuration option -adguard_port that is optional for setting the port to send API request to adguard. 
Linked to issue #4. 