### PR TITLE
Add query log entry counter metric

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,6 +27,16 @@ var (
 		[]string{"hostname"},
 	)
 
+	// DnsQueryLogCount - Counter of log entries seen in query log
+	DnsQueryLogCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:      "dns_query_log_count",
+			Namespace: "adguard",
+			Help:      "Counter of log entries seen in query log",
+		},
+		[]string{"hostname"},
+	)
+
 	// BlockedFiltering - Number of DNS queries blocked
 	BlockedFiltering = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -132,6 +142,7 @@ var (
 func Init() {
 	initMetric("avg_processing_time", AvgProcessingTime)
 	initMetric("num_dns_queries", DnsQueries)
+	initMetric("dns_query_log_count", DnsQueryLogCount)
 	initMetric("num_blocked_filtering", BlockedFiltering)
 	initMetric("num_replaced_parental", ParentalFiltering)
 	initMetric("num_replaced_safebrowsing", SafeBrowsingFiltering)
@@ -144,7 +155,7 @@ func Init() {
 	initMetric("protection_enabled", ProtectionEnabled)
 }
 
-func initMetric(name string, metric *prometheus.GaugeVec) {
+func initMetric(name string, metric prometheus.Collector) {
 	prometheus.MustRegister(metric)
 	log.Printf("New Prometheus metric registered: %s", name)
 }


### PR DESCRIPTION
This adds support for a Counter metric that counts the number of log entries in the query log. It is designed to increase monotonically so that calulations by `rate()` and friends work correctly since they currently do not with `adguard_num_dns_queries`.

The fundamental problem with the current `adguard_num_dns_queries` metric is that it is a gauge, and AdGuard's internal query log GC can cause the gauge to go down.

![adguard_num_dns_queries](https://user-images.githubusercontent.com/1909600/209755525-843f5a6b-3182-4f4b-a868-062b1991b590.png)

This causes problems when trying to do range vector calculations and can cause some wild results.

![rate(adguard_num_dns_queries[5m])](https://user-images.githubusercontent.com/1909600/209755616-11a62b5b-0ddd-4f4c-8133-2fa74a4d410b.png)

By continuously counting the number of new log entries we can have a monotonically increasing counter.

![adguard_dns_query_log_count](https://user-images.githubusercontent.com/1909600/209755672-7f1353bb-f65e-4b30-9566-1094f2ed47de.png)

This makes doing range vector calculations e.g., with `rate()` or `increase()` much saner.

![rate(adguard_dns_query_log_count[5m])](https://user-images.githubusercontent.com/1909600/209755776-f3e73224-3f02-41a3-9738-8a9ea58454c3.png)

Breaks in monotonicity (such as the exporter restarting) are accounted more gracefully for by `rate()` and friends.

![resets(adguard_dns_query_log_count[5m])](https://user-images.githubusercontent.com/1909600/209757183-1fd6597a-5891-4e87-a2fc-6f7a57ccaebc.png)

The gist of how this metric is determined is the `Client` keeps track of a cursor (`logCursor`) which is a hash of the most recent log entry it saw. Every time it runs `setMetrics` it hashes each log entry and compares it to the current cursor. It increments the counter until it matches the cursor. When it reaches the cursor it breaks and sets a new cursor. There's also a check for the case where it isn't able to match up the cursor from the previous batch. While this won't cause significant harm, it makes the metrics inaccurate since it is undercounting the number of log entries. As noted by the error message, the fix is to either increase `log_limit` or decrease the `interval` in the config.

I chose to use a hash derived from a combination of several values in the log entry instead of simply a timestamp to reduce the possibility of collisions. By collisions, I mean where two or more log lines are received by AdGuardHome at the same time and registered with the same timestamp. I will concede that's a _very_ slim probability especially given the timestamps are `time.RFC3339Nano`. However, I figured the extra defensiveness couldn't hurt.

The current cursor only stays in memory and isn't persisted to disk. This means that on startup the exporter cannot accurately count the number of logs that have been generated between checks since there isn't a check to compare against. If it were to count the logs in full, the metric would be artificially inflated based on the `log_limit` since the metric would effectively always start at that value. To combat this, there is a special case where if the cursor isn't set yet, it will skip counting log entries until the next check. Even though there is a potential for a little bit of missed data, this makes range vector calculations more accurate since there isn't artificial metric inflation after a counter reset. Here's an example graph where the first reset _does not_ handle this special case, but second reset _does_:

![metric accuracy after reset](https://user-images.githubusercontent.com/1909600/209757756-865fbdd9-8621-40e2-a5f2-b882c5765124.png)

This uses a `rate(adguard_num_dns_queries)` query (which is okay given a sub-1h window) as a control to show what it _should_ be. Notice how the metric is artificially increased for the duration of the range vector in the first reset. However, in the second reset, it doesn't increase quite as much but loses a small amount of data.


Signed-off-by: sapslaj <saps.laj@gmail.com>